### PR TITLE
Update configure-eden-apache-mysql.sh

### DIFF
--- a/configure-eden-apache-mysql.sh
+++ b/configure-eden-apache-mysql.sh
@@ -74,7 +74,7 @@ git pull
 # -----------------------------------------------------------------------------
 echo "Setting up Web server"
 
-rm -f /etc/apache2/sites-enabled/000-default
+rm -f /etc/apache2/sites-enabled/000-default$extension
 cat << EOF > "/etc/apache2/sites-available/production$extension"
 <VirtualHost *:80>
   ServerName $hostname.$DOMAIN


### PR DESCRIPTION
Nursix pointed out that with Debian 8  "TSince the -configure script tries to remove "000-default" (Debian 7) rather than "000-default.conf" (Debian 8), this does not work so this needs to be fixed