### PR TITLE
Patch Web2py + PyDAL in 2.18.5 for compatibility also with python 3.8

### DIFF
--- a/roles/coapp/files/_compat.patch
+++ b/roles/coapp/files/_compat.patch
@@ -1,13 +1,116 @@
---- _compat.py	Fri Mar 08 12:11:50 2019
-+++ _compat_new.py	Fri Mar 08 12:02:43 2019
-@@ -26,8 +26,9 @@
-     from email.MIMEMultipart import MIMEMultipart
-     from email.MIMEText import MIMEText
-     from email.Charset import add_charset, QP as charset_QP
--    from urllib import FancyURLopener, urlencode, urlopen
-+    from urllib import FancyURLopener, urlencode
-     from urllib import quote as urllib_quote, unquote as urllib_unquote, quote_plus as urllib_quote_plus
-+    from urllib2 import urlopen
+--- gluon/compileapp.py
++++ gluon/compileapp.py
+@@ -61,7 +61,7 @@
+ TEST_CODE = \
+     r"""
+ def _TEST():
+-    import doctest, sys, cStringIO, types, cgi, gluon.fileutils
++    import doctest, sys, cStringIO, types, gluon.fileutils
+     if not gluon.fileutils.check_credentials(request):
+         raise HTTP(401, web2py_error='invalid credentials')
+     stdout = sys.stdout
+--- gluon/languages.py
++++ gluon/languages.py
+@@ -16,7 +16,6 @@
+ import sys
+ import pkgutil
+ import logging
+-from cgi import escape
+ from threading import RLock
+ 
+ from pydal._compat import copyreg, PY2, maketrans, iterkeys, unicodeT, to_unicode, to_bytes, iteritems, to_native, pjoin
+--- gluon/packages/dal/pydal/_compat.py
++++ gluon/packages/dal/pydal/_compat.py
+@@ -32,7 +32,6 @@
+     from urllib2 import urlopen
      from string import maketrans
      from types import ClassType
-     import cgi
+-    import cgi
+     import cookielib
+     from xmlrpclib import ProtocolError
+     BytesIO = StringIO
+Only in web2py: gluon/packages/dal/pydal/_compat.py.orig
+--- gluon/packages/dal/pydal/adapters/oracle.py
++++ gluon/packages/dal/pydal/adapters/oracle.py
+@@ -96,7 +96,7 @@
+         return self.dialect.quote(tablename)
+ 
+     def _build_value_for_insert(self, field, value, r_values):
+-        if field.type is 'text':
++        if field.type == 'text':
+             r_values[':' + field._rname] = self.expand(value, field.type)
+             return ':' + field._rname
+         return self.expand(value, field.type)
+Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
+--- gluon/packages/dal/pydal/contrib/portalocker.py
++++ gluon/packages/dal/pydal/contrib/portalocker.py
+@@ -193,6 +193,9 @@
+     def read(self, size=None):
+         return self.file.read() if size is None else self.file.read(size)
+ 
++    def readinto(self, b):
++        b[:] = self.file.read()
++
+     def readline(self):
+         return self.file.readline()
+ 
+--- gluon/packages/dal/pydal/helpers/classes.py
++++ gluon/packages/dal/pydal/helpers/classes.py
+@@ -532,6 +532,9 @@
+         self.p += len(data)
+         return data
+ 
++    def readinto(self, bytes):
++        return self.read(bytes)
++
+     def readline(self):
+         i = self.data.find('\n', self.p)+1
+         if i > 0:
+--- gluon/packages/dal/pydal/validators.py
++++ gluon/packages/dal/pydal/validators.py
+@@ -148,7 +148,7 @@
+ 
+ 
+ def validator_caller(func, value):
+-    if getattr(func, 'validate', None) is Validator.validate:
++    if getattr(func, 'validate', None) is not Validator.validate:
+         return func.validate(value)
+     value, error = func(value)
+     if error is not None:
+@@ -3154,7 +3154,7 @@
+                 if not all_special.count(True) >= self.special:
+                     failures.append(self.translator("Must include at least %s of the following: %s")
+                                     % (self.special, self.specials))
+-            elif self.special is 0:
++            elif self.special == 0 and self.special is not False:
+                 if len(all_special) > 0:
+                     failures.append(self.translator("May not contain any of the following: %s")
+                                     % self.specials)
+@@ -3169,7 +3169,7 @@
+                 if not len(all_upper) >= self.upper:
+                     failures.append(self.translator("Must include at least %s uppercase")
+                                     % str(self.upper))
+-            elif self.upper is 0:
++            elif self.upper == 0 and self.upper is not False:
+                 if len(all_upper) > 0:
+                     failures.append(
+                         self.translator("May not include any uppercase letters"))
+@@ -3179,7 +3179,7 @@
+                 if not len(all_lower) >= self.lower:
+                     failures.append(self.translator("Must include at least %s lowercase")
+                                     % str(self.lower))
+-            elif self.lower is 0:
++            elif self.lower == 0 and self.lower is not False:
+                 if len(all_lower) > 0:
+                     failures.append(
+                         self.translator("May not include any lowercase letters"))
+@@ -3192,7 +3192,7 @@
+                 if not len(all_number) >= self.number:
+                     failures.append(self.translator("Must include at least %s %s")
+                                     % (str(self.number), numbers))
+-            elif self.number is 0:
++            elif self.number == 0 and self.number is not False:
+                 if len(all_number) > 0:
+                     failures.append(self.translator("May not include any numbers"))
+         if len(failures) == 0:
+Only in web2py: gluon/validators.py.orig

--- a/roles/coapp/tasks/main.yml
+++ b/roles/coapp/tasks/main.yml
@@ -38,17 +38,10 @@
 #  copy: src=_compat.patch dest=/home/setup/gluon/packages/dal/pydal/_compat.patch
 #  become: yes
 
-#- name: Patch PyDAL in 2.18.3
-#  patch:
-#    src: _compat.patch
-#    basedir: /home/setup/gluon/packages/dal/pydal
-#  become: yes
-
-- name: Patch PyDAL in 2.18.5
-  replace:
-    path: /home/setup/gluon/packages/dal/pydal/validators.py
-    regexp: 'if getattr\(func, ''validate'', None\) is Validator\.validate:'
-    replace: 'if getattr(func, ''validate'', None) is not Validator.validate:'
+- name: Patch Web2py + PyDAL in 2.18.5
+  patch:
+    src: _compat.patch
+    basedir: /home/setup
   become: yes
 
 # No Database selected for co-app


### PR DESCRIPTION
This PR patches/backports a few minor fixes in Web2py + PyDAL to support also python 3.8 with the current Web2py 2.18.5, until Sahana moves to a newer version. Without the backports, the unpatched components throw errors or emit warnings.
 - https://github.com/web2py/web2py/commit/eda8277fbdb779852f3383244b191429f0eb2a34 - removed unwanted import that breaks python3.8 
 - https://github.com/web2py/pydal/commit/603b8e0eb6ef026d8beff13c472d91bca1ddbe5 - possibly added python3.8 complaince: readinto
 - https://github.com/web2py/pydal/commit/e595b921b02173bb804a061faa6d54773f18cd81 - fixed some pyhton3.8 issues
 - https://github.com/web2py/pydal/commit/88f179bba6dcdf51b62bbd87c295d2311008a539 - minor fix to support python 3.8 
 - https://github.com/web2py/pydal/commit/f3401dd8c05d089cb49cfd1215e2991388eace09 - Avoid using "is <integer_constant>"
 - \+ the original fix for 2.18.5 Validator already container in the ansible task which is now a part of https://github.com/web2py/pydal/commit/cecd77127c122404c1aee7f6377c6a0150d86d84

Compatibility with older python version is not affected by this PR.