### PR TITLE
Add compat pydal patch for PostGIS 3 support

### DIFF
--- a/roles/coapp/files/_compat.patch
+++ b/roles/coapp/files/_compat.patch
@@ -9,6 +9,25 @@
      if not gluon.fileutils.check_credentials(request):
          raise HTTP(401, web2py_error='invalid credentials')
      stdout = sys.stdout
+--- gluon/globals.py
++++ gluon/globals.py
+@@ -241,7 +241,15 @@
+         # parse POST variables on POST, PUT, BOTH only in post_vars
+         if body and not is_json and env.request_method in ('POST', 'PUT', 'DELETE', 'BOTH'):
+             query_string = env.pop('QUERY_STRING', None)
+-            dpost = cgi.FieldStorage(fp=body, environ=env, keep_blank_values=1)
++            content_disposition = env.get('HTTP_CONTENT_DISPOSITION')
++            if content_disposition:
++                headers = {'content-disposition': content_disposition,
++                           'content-type': env['CONTENT_TYPE'],
++                           'content-length': env['CONTENT_LENGTH'],
++                           }
++            else:
++                headers = None
++            dpost = cgi.FieldStorage(fp=body, environ=env, headers=headers, keep_blank_values=1)
+             try:
+                 post_vars.update(dpost)
+             except:
 --- gluon/languages.py
 +++ gluon/languages.py
 @@ -16,7 +16,6 @@
@@ -29,7 +48,6 @@
      import cookielib
      from xmlrpclib import ProtocolError
      BytesIO = StringIO
-Only in web2py: gluon/packages/dal/pydal/_compat.py.orig
 --- gluon/packages/dal/pydal/adapters/oracle.py
 +++ gluon/packages/dal/pydal/adapters/oracle.py
 @@ -96,7 +96,7 @@
@@ -41,7 +59,6 @@ Only in web2py: gluon/packages/dal/pydal/_compat.py.orig
              r_values[':' + field._rname] = self.expand(value, field.type)
              return ':' + field._rname
          return self.expand(value, field.type)
-Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
 --- gluon/packages/dal/pydal/contrib/portalocker.py
 +++ gluon/packages/dal/pydal/contrib/portalocker.py
 @@ -193,6 +193,9 @@
@@ -54,6 +71,30 @@ Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
      def readline(self):
          return self.file.readline()
  
+--- gluon/packages/dal/pydal/dialects/postgre.py
++++ gluon/packages/dal/pydal/dialects/postgre.py
+@@ -130,8 +130,8 @@
+         return rv
+ 
+     def st_asgeojson(self, first, second, query_env={}):
+-        return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
+-            second['version'], self.expand(first, query_env=query_env),
++        return 'ST_AsGeoJSON(%s,%s,%s)' % (
++            self.expand(first, query_env=query_env),
+             second['precision'], second['options'])
+ 
+     def st_astext(self, first, query_env={}):
+@@ -258,8 +258,8 @@
+         return 'ST_AsText(%s)' % self.expand(first, query_env=query_env)
+     
+     def st_asgeojson(self, first, second, query_env={}):
+-        return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
+-            second['version'], self.expand(first, query_env=query_env),
++        return 'ST_AsGeoJSON(%s,%s,%s)' % (
++            self.expand(first, query_env=query_env),
+             second['precision'], second['options'])
+ 
+     def json_key(self, first, key, query_env=None):
 --- gluon/packages/dal/pydal/helpers/classes.py
 +++ gluon/packages/dal/pydal/helpers/classes.py
 @@ -532,6 +532,9 @@
@@ -113,4 +154,3 @@ Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
                  if len(all_number) > 0:
                      failures.append(self.translator("May not include any numbers"))
          if len(failures) == 0:
-Only in web2py: gluon/validators.py.orig

--- a/roles/common/files/_compat.patch
+++ b/roles/common/files/_compat.patch
@@ -48,7 +48,6 @@
      import cookielib
      from xmlrpclib import ProtocolError
      BytesIO = StringIO
-Only in web2py: gluon/packages/dal/pydal/_compat.py.orig
 --- gluon/packages/dal/pydal/adapters/oracle.py
 +++ gluon/packages/dal/pydal/adapters/oracle.py
 @@ -96,7 +96,7 @@
@@ -60,7 +59,6 @@ Only in web2py: gluon/packages/dal/pydal/_compat.py.orig
              r_values[':' + field._rname] = self.expand(value, field.type)
              return ':' + field._rname
          return self.expand(value, field.type)
-Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
 --- gluon/packages/dal/pydal/contrib/portalocker.py
 +++ gluon/packages/dal/pydal/contrib/portalocker.py
 @@ -193,6 +193,9 @@
@@ -73,6 +71,30 @@ Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
      def readline(self):
          return self.file.readline()
  
+--- gluon/packages/dal/pydal/dialects/postgre.py
++++ gluon/packages/dal/pydal/dialects/postgre.py
+@@ -130,8 +130,8 @@
+         return rv
+ 
+     def st_asgeojson(self, first, second, query_env={}):
+-        return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
+-            second['version'], self.expand(first, query_env=query_env),
++        return 'ST_AsGeoJSON(%s,%s,%s)' % (
++            self.expand(first, query_env=query_env),
+             second['precision'], second['options'])
+ 
+     def st_astext(self, first, query_env={}):
+@@ -258,8 +258,8 @@
+         return 'ST_AsText(%s)' % self.expand(first, query_env=query_env)
+     
+     def st_asgeojson(self, first, second, query_env={}):
+-        return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
+-            second['version'], self.expand(first, query_env=query_env),
++        return 'ST_AsGeoJSON(%s,%s,%s)' % (
++            self.expand(first, query_env=query_env),
+             second['precision'], second['options'])
+ 
+     def json_key(self, first, key, query_env=None):
 --- gluon/packages/dal/pydal/helpers/classes.py
 +++ gluon/packages/dal/pydal/helpers/classes.py
 @@ -532,6 +532,9 @@
@@ -132,4 +154,3 @@ Only in web2py: gluon/packages/dal/pydal/adapters/oracle.py.orig
                  if len(all_number) > 0:
                      failures.append(self.translator("May not include any numbers"))
          if len(failures) == 0:
-Only in web2py: gluon/validators.py.orig


### PR DESCRIPTION
This PR backports the meaningful part of https://github.com/web2py/pydal/commit/06abf2ae19404262c1916c619209129753765918 (https://github.com/web2py/pydal/pull/623) to ensure compatibility with PostGIS 3. Without it, various messages such as
```
2020-04-21 22:54:31.681 CEST [14] sahana@sahana ERROR:  function st_asgeojson(integer, geometry, integer, integer) does not exist at character 29
2020-04-21 22:54:31.681 CEST [14] sahana@sahana HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
2020-04-21 22:54:31.681 CEST [14] sahana@sahana STATEMENT:  SELECT "gis_location"."id", ST_AsGeoJSON(1,ST_SimplifyPreserveTopology("gis_location"."the_geom",0.01),4,0) AS geojson FROM "gis_location" WHERE ("gis_location"."id" IN (249));
```
are appearing in Postgres log when working with map layers, which results in some of the layers not displaying POI and possibly other problems.

The PR also removes meaningless lines from diff output sent in #9 by accident.

I wasn't sure which of the compat files is the correct one, so I've updated both.