### PR TITLE
Switch to web2py-2.21.1

### DIFF
--- a/roles/coapp/tasks/main.yml
+++ b/roles/coapp/tasks/main.yml
@@ -13,8 +13,8 @@
   git: # recursive by default
     repo: git://github.com/web2py/web2py.git
     dest: /home/setup
-    # 2.20.4
-    version: 777c305
+    # 2.21.1
+    version: 6da8479
     # Don't update unless explicitly desired
     update: no
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -97,8 +97,8 @@
   git: # recursive by default
     repo: git://github.com/web2py/web2py.git
     dest: /home/{{ type}}
-    # 2.20.4
-    version: 777c305
+    # 2.21.1
+    version: 6da8479
     # Don't update unless explicitly desired
     update: no
   become: yes


### PR DESCRIPTION
- compatibility-fixed in both trunk and stable
- field-tested with RLP
